### PR TITLE
Translate: Copy all files, not just *.py

### DIFF
--- a/trubar/actions.py
+++ b/trubar/actions.py
@@ -9,8 +9,7 @@ import libcst as cst
 from libcst.metadata import ParentNodeProvider
 
 __all__ = ["collect", "translate", "merge", "missing", "template",
-           "load", "dump",
-           "any_translations"]
+           "load", "dump"]
 
 MsgDict = Dict[str, Union["MsgDict", str]]
 NamespaceNode = Union[cst.Module, cst.FunctionDef, cst.ClassDef]
@@ -190,8 +189,6 @@ def translate(translations: MsgDict,
     source = source or "."
     destination = destination or "."
     for name, fullname in walk_files(source, pattern):
-        if not quiet and not any_translations(translations.get(name, {})):
-            print(f"{name}: no translations")
         with open(fullname, encoding=__encoding) as f:
             orig_source = f.read()
             tree = cst.parse_module(orig_source)
@@ -283,9 +280,3 @@ def dump(messages: MsgDict, filename: str) -> None:
     with open(filename, "wb") as f:
         f.write(yaml.dump(messages, indent=4, sort_keys=False,
                           encoding="utf-8", allow_unicode=True))
-
-
-def any_translations(context):
-    return any(any_translations(obj) if isinstance(obj, dict)
-               else isinstance(obj, str)
-               for obj in context.values())

--- a/trubar/tests/test_actions.py
+++ b/trubar/tests/test_actions.py
@@ -173,7 +173,7 @@ class UtilsTest(unittest.TestCase):
     def test_walk_files(self):
         tmp = test_module_path
         self.assertEqual(
-            set(walk_files(tmp)),
+            set(walk_files(tmp, skip_nonpython=True)),
             {('bar_module/__init__.py',
               f'{tmp}/bar_module/__init__.py'),
              ('bar_module/foo_module/__init__.py',
@@ -188,7 +188,7 @@ class UtilsTest(unittest.TestCase):
         try:
             os.chdir(tmp)
             self.assertEqual(
-                set(walk_files(".")),
+                set(walk_files(".", skip_nonpython=True)),
                 {('bar_module/__init__.py',
                   './bar_module/__init__.py'),
                  ('bar_module/foo_module/__init__.py',
@@ -199,7 +199,7 @@ class UtilsTest(unittest.TestCase):
                   './__init__.py')}
             )
             self.assertEqual(
-                set(walk_files(".", "bar")),
+                set(walk_files(".", "bar", skip_nonpython=True)),
                 {('bar_module/__init__.py',
                   './bar_module/__init__.py'),
                  ('bar_module/foo_module/__init__.py',
@@ -207,6 +207,20 @@ class UtilsTest(unittest.TestCase):
             )
         finally:
             os.chdir(old_path)
+
+        self.assertEqual(
+            set(walk_files(tmp, skip_nonpython=False)),
+            {('bar_module/__init__.py',
+              f'{tmp}/bar_module/__init__.py'),
+             ('bar_module/foo_module/__init__.py',
+              f'{tmp}/bar_module/foo_module/__init__.py'),
+             ('baz_module/__init__.py',
+              f'{tmp}/baz_module/__init__.py'),
+             ('__init__.py',
+              f'{tmp}/__init__.py'),
+             ('baz_module/not-python.js',
+              f'{tmp}/baz_module/not-python.js')}
+        )
 
 
 class ActionsTest(unittest.TestCase):

--- a/trubar/tests/test_command_line.sh
+++ b/trubar/tests/test_command_line.sh
@@ -33,16 +33,23 @@ rm messages.yaml
 echo
 echo "Translate"
 print_run 'trubar translate -s test_project -d test_translations test_project/translations.yaml -q'
-diff -r -x "*.yaml" test_translations si_translations
+diff -r -x "*.yaml" -x "*.txt" test_translations si_translations
 rm -r test_translations
 
 echo "... with pattern"
 mkdir test_translations
 cp test_project/__init__.py test_translations/__init__.py
 print_run 'trubar translate -s test_project -d test_translations test_project/translations.yaml -p submodule -q'
+diff -r test_translations/submodule si_translations/submodule
 diff test_translations/__init__.py test_project/__init__.py
-diff test_translations/submodule/apples.py si_translations/submodule/apples.py
 rm -r test_translations
+
+echo "... dry run"
+cp -r test_project test_translations
+print_run 'trubar translate -s test_project -d test_translations test_project/translations.yaml -q -n'
+diff -r test_project test_translations
+rm -r test_translations
+
 
 echo
 echo "Merge"


### PR DESCRIPTION
Fixes #23: copy non-python files in translate.