### PR TITLE
Add auto quotes and prefixes, and config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,17 +113,17 @@ The effect of changing `null` to `false` is that `trubar missing` will treat the
 
 #### Quotes
 
-Messages are shown as strings without quotes. This may cause some problems because it doesn't show the translator which type of quotes is used in the source. It is however preferable to including quotes, because YAML would add quotes to quoted strings and translator would have to do the same.
+The use of quotes in YAML is optional, unless needed to properly interpret the value. When in doubt, use them. Double quoted strings interpret \n as newline; to have \n in Python source, use \\n. Or single quotes.
 
-When in doubt, check the source.
-
-YAML however adds quotes if the messages contains certain characters or ends with semicolon or space. Translator must do the same to conform to YAML format. This doesn't mean that quotes must be present (absent) if they are present (absent) in the original. Quotes can be omitted if unnecessary, and must be added when necessary.
+The quotes used in YAML are unrelated to quotes used in the corresponding Python code, hence the messages file does not show the type of the quote used in the original source. This could cause problems if translation contains, for instance, a single quote and the Python string itself is enclosed in single quotes. Trubar will detect that and replace the enclosing quotes in translated code, *unless* the translation contains both types of quotes *or* this is explicitly disabled in configuration file.
 
 #### f-strings
 
-The file with translations does not (and cannot indicate without a lot of additional clutter) whether the string is an f-string or not. This can be deduced by the presence of `{...}` within the string ... or checked in the code.
+The file with translations does not indicate whether the string is an f-string or not. This can be deduced by the presence of `{...}` within the string or checked in the code.
 
-Translator cannot replace an ordinary string with an f-string, because (s)he touches only what is between the quotes. If, however, translator decides to exclude data that is interpolated, (s)he may do so by simply omitting the parts between braces; this is still a valid (though pointless) f-string.
+If translation includes braces, and if all pairs of braces contain parsable Python expressions, Trubar will add the f-prefix to the string, *unless* this is explicitly disabled in configuration file.
+
+If the original string is an f-string, the prefix is not removed even if the translation does not contain any braces.
 
 #### Plural forms
 
@@ -176,13 +176,12 @@ Do whatever you want. Translate the first line or multiple lines ... it won't ch
 
 Future versions of `trubar` may improve in this respect.
 
-### Known quirks
+### Configuration options
 
-Trubar currently assumes that no string is the same as a function within the same namespace. This would cause problems.
+By default, Trubar reads configuration from trubar-config.yaml in the current directory. Another file can be given by `--conf` option.
 
-```python
-s = "foo"
+Configuration file can contain the following options:
 
-def foo(x):
-    t = "bar"
-```
+- **auto-quotes**: if *true* (default) Trubar will detect single (double) quotes in translations and change the enclosing quotes to double (single), when necessary.
+- **auto-prefix**: if *true* (default) Trubar adds the f-prefix if translation looks like an f-string, but the original string was not an f-string
+- **encoding**: define a text file encoding different from locale.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+libcst
+pyyaml

--- a/trubar/__main__.py
+++ b/trubar/__main__.py
@@ -1,9 +1,11 @@
 import argparse
+import os
 import sys
 
 from trubar.actions import \
     load, dump, \
     collect, translate, merge, missing, template
+from trubar.config import config
 
 
 def main() -> None:
@@ -15,6 +17,9 @@ def main() -> None:
         return subparser
 
     argparser = argparse.ArgumentParser()
+    argparser.add_argument(
+        "--conf", default="", metavar="configuration-file",
+        help="configuration file")
     subparsers = argparser.add_subparsers(required=True, dest="action")
 
     parser = add_parser("collect", "Collect message strings in source files")
@@ -85,6 +90,11 @@ def main() -> None:
         help="missing translations")
 
     args = argparser.parse_args(sys.argv[1:])
+
+    if args.conf:
+        config.update_from_file(args.conf)
+    elif os.path.exists("trubar-config.yaml"):
+        config.update_from_file("trubar-config.yaml")
 
     pattern = args.pattern
 

--- a/trubar/config.py
+++ b/trubar/config.py
@@ -1,0 +1,48 @@
+import sys
+import os
+import locale
+import dataclasses
+
+import yaml
+
+
+@dataclasses.dataclass
+class Configuration:
+    auto_quotes: bool = True
+    auto_prefix: bool = True
+
+    encoding: str = \
+        "locale" if sys.version_info >= (3, 10) \
+        else locale.getpreferredencoding(False)
+
+    def update_from_file(self, filename):
+        if not os.path.exists(filename):
+            print(f"Can't open configuration file {filename}")
+            sys.exit(4)
+        try:
+            with open(filename, encoding=self.encoding) as f:
+                settings = yaml.load(f, Loader=yaml.Loader)
+        except yaml.YAMLError as exc:
+            print(f"Invalid configuration file: {exc}")
+            sys.exit(4)
+
+        fieldict = {field.name: field for field in dataclasses.fields(self)}
+        for name, value in settings.items():
+            name = name.replace("-", "_")
+            field = fieldict.get(name, None)
+            if field is None:
+                print(f"Unrecognized configuration setting: {name}")
+                sys.exit(4)
+            if field.type is bool and value not in (True, False):
+                print(f"Invalid value for '{name}': {value}")
+                sys.exit(4)
+            else:
+                try:
+                    value = field.type(value)
+                except ValueError:
+                    print(f"Invalid value for '{name}': {value}")
+                    sys.exit(4)
+            setattr(self, name, value)
+
+
+config = Configuration()

--- a/trubar/tests/test_command_line.sh
+++ b/trubar/tests/test_command_line.sh
@@ -151,6 +151,31 @@ diff errors_structure.txt test_project/errors_structure.txt
 rm errors_structure.txt
 
 echo
+echo "Read configuration"
+echo "... default is to turn strings to f-strings when needed"
+print_run 'trubar translate -s test_project -d test_translations test_project/newly_braced.yaml -q'
+set +e
+grep -q "a = f\"A {'clas' + 's'} attribute\"" test_translations/__init__.py
+if [ $? -ne 0 ]
+then
+    echo "Invalid initial configuration? String was not changed to f-string"
+    exit 1
+fi
+set -e
+
+echo "... but this can be disabled in settings"
+print_run 'trubar --conf test_project/config-no-prefix.yaml translate -s test_project -d test_translations test_project/newly_braced.yaml -q'
+set +e
+grep -q "a = \"A {'clas' + 's'} attribute\"" test_translations/__init__.py
+if [ $? -ne 0 ]
+then
+    echo "Configuration not read? String was still changed to f-string"
+    exit 1
+fi
+set -e
+rm -r test_translations
+
+echo
 echo "Done."
 )
 

--- a/trubar/tests/test_config.py
+++ b/trubar/tests/test_config.py
@@ -1,0 +1,69 @@
+import dataclasses
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+from trubar.config import Configuration
+
+
+class ExitCalled(Exception):
+    pass
+
+
+class ConfigTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tmpdir = tempfile.mkdtemp()
+        cls.fn = os.path.join(cls.tmpdir, "test.yaml")
+        cls.old_exit = sys.exit
+        sys.exit = Mock(side_effect=ExitCalled)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        shutil.rmtree(cls.tmpdir)
+        sys.exit = cls.old_exit
+
+    def prepare(self, s):
+        with open(self.fn, "w") as f:
+            f.write(s)
+
+    def test_proper_file(self):
+        config = Configuration()
+        self.prepare("auto_quotes: false\n\nencoding: cp-1234")
+        config.update_from_file(self.fn)
+        self.assertFalse(config.auto_quotes)
+        self.assertTrue(config.auto_prefix)
+        self.assertEqual(config.encoding, "cp-1234")
+
+    def test_malformed_file(self):
+        config = Configuration()
+        self.prepare("auto_quotes: false\n\nencoding")
+        self.assertRaises(ExitCalled, config.update_from_file, self.fn)
+
+    def test_unrecognized_option(self):
+        config = Configuration()
+        self.prepare("auto_quotes: false\n\nauto_magog: false")
+        self.assertRaises(ExitCalled, config.update_from_file, self.fn)
+
+    def test_invalid_type(self):
+        # At the time of writing, Configuration had only bool and str settings,
+        # which can never fail on conversion. To raach that code in test, we
+        # imagine setting that can
+        # Data classes do not support inheritance, so we patch the tested method
+        # into a new class.
+        @dataclasses.dataclass
+        class ConfigurationWithInt:
+            encoding: str = "ascii"
+            foo: int = 42
+            update_from_file = Configuration.update_from_file
+
+        config = ConfigurationWithInt()
+        self.prepare("foo: bar")
+        self.assertRaises(ExitCalled, config.update_from_file, self.fn)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trubar/tests/test_project/config-no-prefix.yaml
+++ b/trubar/tests/test_project/config-no-prefix.yaml
@@ -1,0 +1,1 @@
+auto-prefix: false

--- a/trubar/tests/test_project/newly_braced.yaml
+++ b/trubar/tests/test_project/newly_braced.yaml
@@ -1,0 +1,3 @@
+__init__.py:
+    class `A`:
+        A class attribute: A {'clas' + 's'} attribute


### PR DESCRIPTION
Fixes #32.

This adds two relatively unrelated functionalities:
- changes in string types and prefixes:
    - single quotes in source are replaced with double quotes and vice-versa, when the translation includes quotes
    - string is changed to f-string if translation requires it
- configuration file with global options; currently auto-quote, auto-prefix, encoding

They are merged into the same PR because the former is regulated by the latter, and the latter is unittested by its ability to control the former.