### PR TITLE
Auto prefix: Better detection of use of f-strings in translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ The quotes used in YAML are unrelated to quotes used in the corresponding Python
 
 The file with translations does not indicate whether the string is an f-string or not. This can be deduced by the presence of `{...}` within the string or checked in the code.
 
-If translation includes braces, and if all pairs of braces contain parsable Python expressions, Trubar will add the f-prefix to the string, *unless* this is explicitly disabled in configuration file.
+Even if the original is not an f-string, the translation can be an f-string, for instance to add plural forms. Trubar checks whether the translation can be parsed as an f-string and the result contains any expressions, it will add the f-prefix to the string. If in particular project this would lead to false positives, it can be explicitly disabled (but project-wide!) in configuration file.
 
-If the original string is an f-string, the prefix is not removed even if the translation does not contain any braces.
+If the original string is an f-string, the prefix is never removed.
 
 #### Plural forms
 

--- a/trubar/tests/test_actions.py
+++ b/trubar/tests/test_actions.py
@@ -175,6 +175,8 @@ class C:
 print("Foo")
 print('Bar')
 print("2 + 2 = 4")
+print("2 + 3 = 4")
+print("2 + 4 = 4")
 print("baz")
 print("kux")
 print(r"bing")
@@ -186,6 +188,8 @@ print(\"\"\"f y g\"\"\")
         translations = {"Foo": 'Fo"o',
                         "Bar": "B'ar",
                         "2 + 2 = 4": "2 + 2 = {2 + 2}",
+                        "2 + 3 = 4": "2 + 3 = {}",
+                        "2 + 4 = 4": "2 + 4 = {not an expression}",
                         "baz": "ba{}z",
                         "kux": "ku{--}x",
                         "bing": "b{2 + 2}ng",
@@ -199,9 +203,11 @@ print(\"\"\"f y g\"\"\")
 print('Fo"o')
 print("B'ar")
 print(f"2 + 2 = {2 + 2}")
+print("2 + 3 = {}")
+print("2 + 4 = {not an expression}")
 print("ba{}z")
 print("ku{--}x")
-print(rf"b{2 + 2}ng")
+print(fr"b{2 + 2}ng")
 print('''f ' g''')
 print(\"\"\"f " g\"\"\")
 """)


### PR DESCRIPTION
Fixes #35.

Instead of relying on regular expressions, try parsing the string as f-string and convert it to f-string if this succeeds and finds any expressions inside the string.

To save time, do this only if the string contains a pair of braces, as check by simple regular expression (`\{.+\}`).