### PR TITLE
Don't add f-prefix if braces were already there

### DIFF
--- a/trubar/actions.py
+++ b/trubar/actions.py
@@ -165,8 +165,8 @@ class StringTranslator(cst.CSTTransformer):
                 quote = "'"
 
         if config.auto_prefix \
-                and "f" not in node.prefix \
-                and re_braced.search(translation):
+                and "f" not in node.prefix and not re_braced.search(original) \
+                and re_braced.search(translation) :
             try:
                 new_node = cst.parse_expression(
                     f'f{node.prefix}{quote}{translation}{quote}')

--- a/trubar/tests/test_actions.py
+++ b/trubar/tests/test_actions.py
@@ -185,6 +185,7 @@ print("kux")
 print(r"bing")
 print('''f x g''')
 print(\"\"\"f y g\"\"\")
+print("just {braces}, not an f-string!")
 """
 
         tree = cst.parse_module(module)
@@ -198,6 +199,7 @@ print(\"\"\"f y g\"\"\")
                         "bing": "b{2 + 2}ng",
                         "f x g": "f ' g",
                         "f y g": 'f " g',
+                        "just {braces}, not an f-string!": "samo {oklepaji}!"
                         }
         translator = yamlized(StringTranslator)(translations, tree)
         translated = tree.visit(translator)
@@ -213,6 +215,7 @@ print("ku{--}x")
 print(fr"b{2 + 2}ng")
 print('''f ' g''')
 print(\"\"\"f " g\"\"\")
+print("samo {oklepaji}!")
 """)
 
 


### PR DESCRIPTION
Fixes #45.

If translation includes something that looks like f-string, but the original already included braces, don't add the f-prefix.