### PR TITLE
Don't escape backslashes in unquoted strings

### DIFF
--- a/trubar/jaml.py
+++ b/trubar/jaml.py
@@ -180,7 +180,7 @@ def dump(d, indent=""):
             return f"{dumpb(s)}\n{indent}"
         if ":" in s or s[0] in " #\"'|":
             return repr(s)
-        return repr(s)[1:-1]  # replace \n characters with `"\n"` etc.
+        return s
 
     def dumpval(s):
         trans = {True: "true", False: "false", None: "null",
@@ -191,7 +191,7 @@ def dump(d, indent=""):
             return dumpb(s)
         if _is_quoted_value(s):  # if value would be recognized as quoted...
             return repr(s)
-        return repr(s)[1:-1]  # replace \n characters with `"\n"` etc.
+        return s
 
     res = ""
     for key, node in d.items():

--- a/trubar/tests/test_jaml.py
+++ b/trubar/tests/test_jaml.py
@@ -148,6 +148,19 @@ abc:
                 comments=None)}
         )
 
+    def test_read_backslashes(self):
+        text = r"""
+fo\no1: ba\nr
+fo\x: ba\x
+"ra\nbit": "za\njec"
+"ra\\nbot": "za\\njoc"
+"""
+        msgs = jaml.read(text)
+        self.assertEqual(msgs, {r'fo\no1': MsgNode(value=r'ba\nr', comments=None),
+ r'fo\x': MsgNode(value=r'ba\x', comments=None),
+ 'ra\nbit': MsgNode(value='za\njec', comments=None),
+ r'ra\nbot': MsgNode(value=r'za\njoc', comments=None)})
+
     def test_read_quotes(self):
         text = """
 foo1: "bar 
@@ -345,6 +358,10 @@ a/b.py:
     yada: true
 class `A`: false
 """[1:])
+
+    def test_backslashes(self):
+        self.assertEqual(jaml.dump({r"a\nb": MsgNode(r"c\nd")}).strip(),
+                         r"a\nb: c\nd")
 
     def test_dump_quotes(self):
         self.assertEqual(jaml.dump({"'foo'": MsgNode("'asdf'")}),


### PR DESCRIPTION
Fix an error in jaml.dump: If strings are not quoted, backslashes mustn't be escaped