### PR TITLE
jaml.dump: use quotes for strings with leading/trailing spaces

### DIFF
--- a/trubar/jaml.py
+++ b/trubar/jaml.py
@@ -178,7 +178,7 @@ def dump(d, indent=""):
     def dumpkey_msg(s):
         if "\n" in s:
             return f"{dumpb(s)}\n{indent}"
-        if ":" in s or s[0] in " #\"'|":
+        if ":" in s or s[0] in " #\"'|" or s[-1] == " ":
             return repr(s)
         return s
 
@@ -189,7 +189,9 @@ def dump(d, indent=""):
             return trans[s]
         if "\n" in s[1:-1] and len(s) > 80:
             return dumpb(s)
-        if _is_quoted_value(s):  # if value would be recognized as quoted...
+        # if value would be recognized as quoted, it must be quoted
+        # leading or trailing spaces also require quoting
+        if _is_quoted_value(s) or s[0] == " " or s[-1] == " ":
             return repr(s)
         return s
 

--- a/trubar/tests/test_jaml.py
+++ b/trubar/tests/test_jaml.py
@@ -371,6 +371,12 @@ class `A`: false
         self.assertEqual(jaml.dump({"'foo": MsgNode("asdf'")}),
                          """\"'foo": asdf'\n""")
 
+    def test_dump_spaces_in_value(self):
+        self.assertEqual(jaml.dump({"foo": MsgNode("bar ")}),
+                         "foo: 'bar '\n")
+        self.assertEqual(jaml.dump({"foo": MsgNode(" bar")}),
+                         "foo: ' bar'\n")
+
     def test_quoting_keys(self):
         self.assertEqual(jaml.dump({"| ": MsgNode(True)}),
                          "'| ': true\n")
@@ -378,6 +384,8 @@ class `A`: false
                          "'# ': true\n")
         self.assertEqual(jaml.dump({" x": MsgNode(True)}),
                          "' x': true\n")
+        self.assertEqual(jaml.dump({"x ": MsgNode(True)}),
+                         "'x ': true\n")
         self.assertEqual(jaml.dump({" x: y": MsgNode(True)}),
                          "' x: y': true\n")
 


### PR DESCRIPTION
Strings with leading or trailing spaces were not quoted. This would work in principle, but raise warnings from git, and could be disturbed by editors.