### PR TITLE
Jaml: Catch syntax errors in quoted strings

### DIFF
--- a/trubar/jaml.py
+++ b/trubar/jaml.py
@@ -131,7 +131,10 @@ def readlines(lines):
             if mo is None:
                 raise error("invalid quoted key")
             key, value = mo.group("key", "value")
-            key = ast.literal_eval(key)
+            try:
+                key = ast.literal_eval(key)
+            except SyntaxError as exc:
+                error(f"invalid quoted key: {exc}")
             value = value.strip()
         # Key is normal
         else:
@@ -148,7 +151,10 @@ def readlines(lines):
             # value is quoted
             elif _is_quoted_value(value):
                 # unescape quotes
-                value = ast.literal_eval(value)
+                try:
+                    value = ast.literal_eval(value)
+                except SyntaxError as exc:
+                    error(f"invalid quoted value: {exc}")
             else:
                 value = {"true": True, "false": False, "null": None
                          }.get(value, value)

--- a/trubar/tests/test_jaml.py
+++ b/trubar/tests/test_jaml.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from trubar import jaml
 from trubar.jaml import LineGenerator
@@ -263,6 +263,17 @@ ghi: jkl
             
             """,
         )
+
+    def test_syntax_errors(self):
+        self.assertRaisesRegex(
+            jaml.JamlError, "Line 1: invalid quoted key", jaml.read, "'''x: y")
+
+        # I don't know how to actually trigger a syntax error in value string;
+        # it's easier to just mock it.
+        with patch("ast.literal_eval", Mock(side_effect=SyntaxError)):
+            self.assertRaisesRegex(
+                jaml.JamlError, "Line 1: invalid quoted value",
+                jaml.read, 'x:"y"')
 
     def test_format_errors(self):
         # This function checks for exact error messages. While this is not


### PR DESCRIPTION
Quoted strings are parsed by `ast.literal_eval` that can trigger syntax errors. Now they are properly caught and reported.