### PR TITLE
Jaml: Simplify quoting

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -53,9 +53,9 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
-    missing-docstring,  # I guess not
-    no-else-return,     # else's may actually improve readability
-    too-many-branches   # distracting rather than helpful
+    missing-docstring,              # I guess not
+    no-else-return, no-else-raise,  # else's may actually improve readability
+    too-many-branches               # distracting rather than helpful
 
 
 [REPORTS]


### PR DESCRIPTION
Fixes #57.

Backslashes no longer have any special meaning; reading no longer uses `ast.literal_eval`.

- In keys, any quotes within the string that match the outer quote are doubled (instead of escaped). This will be uncommon, and even when it happens, translator does not care.
- In quoted translations, the leading and trailing quote are stripped.  Inside can contain quotes of any kind and whatever else.