### PR TITLE
Test for block values, and minor change

### DIFF
--- a/trubar/jaml.py
+++ b/trubar/jaml.py
@@ -73,7 +73,7 @@ def readlines(lines):
                 if block_indent == 0 and line == "|||":
                     break
             block += line[block_indent:] + "\n"
-        return block.strip("\n")
+        return block[:-1]
 
     def check_no_comments():
         if comments:

--- a/trubar/tests/test_jaml.py
+++ b/trubar/tests/test_jaml.py
@@ -148,6 +148,40 @@ abc:
                 comments=None)}
         )
 
+        text = """
+abc:
+    |
+       ghi
+                abc
+                    dfg
+               jkl
+    : |
+                hjk
+                              ghj
+                                   lkj
+                    pqr
+    |
+       ghi2
+                abc
+                    dfg
+               jkl
+    : |
+                hjk
+                              ghj
+                                   lkj
+                    pqr"""
+        key = """ghi
+         abc
+             dfg
+        jkl"""
+        value = """hjk
+              ghj
+                   lkj
+    pqr"""
+        tr = jaml.read(text)["abc"].value
+        self.assertEqual(tr[key].value, value)
+        self.assertEqual(tr[key.replace("ghi", "ghi2")].value, value)
+
     def test_read_quotes_in_values(self):
         text = """
 foo1: "bar 


### PR DESCRIPTION
Add tests for block values + minor change in parsing: `strip("\n")` is replaced by `[:-1]`, which should be the same, but the latter is closer to the actual intention - removing the trailing `\n` that was "needlessly" added.