### PR TITLE
Jaml: Remove yaml-style pipe blocks in favour of multiline strings

### DIFF
--- a/docs/message-files.md
+++ b/docs/message-files.md
@@ -36,21 +36,17 @@ A comment is always associated with some particular translation or entire functi
 
 ### Quotes
 
-Rules for quoting original messages and translations are different. The former - which are produced automatically - require more quotes to make the latter - which are written by human -- simpler. Here are the rules for the latter, that is, translations.
+- Translation must be quoted if it
 
-- Translations need to be quoted if
+    - begins or end with space,
+    - begins with a quote (single or double)
+    - it is (literally) `"false"`, `"true"` or `"null"`,
 
-    - they begin or end with space,
-    - the translation is (literally) `"false"`, `"true"` or `"null"`,
-    - the actual content of the string begins and ends with a quote of the same type, in which case jaml parser would interpret literal quotes as quotes.
+(In addition, keys are quoted if they contain a colon followed by a space. But translator doesn't need to care because keys are provided by Trubar.)
 
-    You will most likely only encounter the first case.
+Single- and double-quoted strings are treated the same. The translation must begin and end with the same type of quote. The quotes used in message files are not related to the quotes used in source code. In the introductory example, all string in code use double quotes, while some strings in the message file are single-quoted and others double quoted, for convenience.
 
-- Single- and double-quoted strings are treated the same.
-- The translation must begin and end with the same type of quote.
-- A single-quoted string may contain double quotes and vice-versa; such quotes are treated literally.
-- Any single (double) quotes within a single (double) quoted strings must be doubled, as in `'don''t forget to double the quotes.'`.
-- The quotes used in message files are not related to the quotes used in source code. In the introductory example, all string in code use double quotes, while some strings in the message file are single-quoted and others double quoted, for convenience.
+A single-quoted string may contain double quotes and vice-versa; such quotes are treated literally. Any single (double) quotes within a single (double) quoted strings must be doubled, as in `'don''t forget to double the quotes.'`.
 
 ### Colons
 
@@ -62,25 +58,8 @@ Colons in translations have no special meaning. Consider the following line from
 
 In standard yaml, the translation would need quotes because it includes a colon followed by space. In Jaml, this rule only applies to keys, which translator doesn't care about. Therefore: use colons at will.
 
-### Blocks
+### Multiline messages
 
-Multiline strings are usually stored as multiline blocks. These are indicated by using a pipe symbol (`|`) as the only symbol in the line (for original messages) or after the colon (for translations). The proceeding lines must be indented. The indendation level is arbitrary and is deduced from the first line; if it starts with 20 spaces, the leading 20 spaces will be removed from every following line of the block. The block ends at the first line that is indented by less than the first line of the block.
+Strings can span over multiple lines. All whitespace in multiline strings is retained.
 
-Here is an actual example.
-
-```
-widgets/data/__init__.py:
-    Widgets for data manipulation.: Gradniki za obdelavo podatkov.
-    |
-        This category contains widgets for data manipulation. This includes
-        loading, importing, saving, preprocessing, selection, etc.
-    : |
-        Kategorija vsebuje gradnike za delo s podatki, na primer branje,
-        shranjevanje, spreminjanje, izbiranje in podobno.
-```
-
-If the first line of translation contains leading spaces and thus cannot serve to indicate the indentation, the indendation must be indicated by a number following the `|` symbol. E.g., if the first line in indented by 4 additional spaces, the block would begin with `|4`.
-
-Block messages can be translated with non-block strings and vice-versa.
-
-You will probably only use blocks when the key already uses them. Copy the key and replace the text.
+JAML does not support any of the more complicated yaml syntax for multiline blocks.

--- a/trubar/__main__.py
+++ b/trubar/__main__.py
@@ -131,7 +131,7 @@ def main() -> None:
         if os.path.exists(args.messages):
             existing = load(args.messages)
             removed = merge(existing, messages, pattern,
-                            print_unused=bool(args.removed))
+                            print_unused=not args.removed)
             if args.removed and removed:
                 dump(removed, args.removed)
         if not args.dry_run:

--- a/trubar/jaml.py
+++ b/trubar/jaml.py
@@ -50,10 +50,24 @@ def readlines(lines):
     def error(msg, line=None):
         raise JamlError(f"Line {line or linegen.line_no}: {msg}") from None
 
+    def read_triple_quoted_block(line, lineno):
+        block = ""
+        quotes, line = line[:3], line[3:]
+        while quotes not in line:
+            block += line + "\n"
+            try:
+                line, _ = next(linegen)
+            except StopIteration:
+                error(f"file ends before the end of triple-quoted block",
+                      lineno)
+        inside, _, after = line.partition(quotes)
+        block += inside
+        return block.replace(("\\" + quotes[0]) * 3, quotes), after
+
     def read_block(prev_indent, extra_indent):
         if extra_indent.strip():
             try:
-                block_indent = prev_indent  + int(extra_indent)
+                block_indent = prev_indent + int(extra_indent)
             except ValueError:
                 error("block indentation must be a number")
         else:
@@ -86,9 +100,9 @@ def readlines(lines):
     linegen = LineGenerator(lines)
     for line, indent in linegen:
         # Skip empty lines
-        sline = line.strip()
-        if not sline:
+        if not line.strip():
             continue
+        line = line[indent:]
 
         # Indentation
         last_indent, _, indent_expected = stack[-1]
@@ -106,56 +120,71 @@ def readlines(lines):
                 error("unindent does not match any outer level")
 
         # Gather comments
-        if sline[0] == "#":
-            comments.append(sline)
+        if line[0] == "#":
+            comments.append(line)
             comment_start = comment_start or linegen.line_no
             continue
 
         # Get key and value
-        # Key is block
-        if sline[0] == "|":
-            key = read_block(indent, sline[1:])
+        # Key is triple-quoted block
+        if line[:3] in ("'''", '"""'):
+            key, after = read_triple_quoted_block(line, linegen.line_no)
+            if after[:2] != ": ":
+                error("triple-quoted key must be followed by a ': '")
+            else:
+                value = after[2:].lstrip()
+        # block - backward compatibility
+        elif line[0] == "|":
+            key = read_block(indent, line[1:])
             try:
                 line, value_indent = next(linegen)
             except StopIteration:
                 error("missing value after block key")
             if value_indent != indent:
                 error("value after block key must be aligned with key")
-            value = line.lstrip().lstrip(":").strip()
+            value = line[indent:]
+            if not value.startswith(": "):
+                error("block key must be followed by ': '")
+            value = value[2:].lstrip()
         # Key is quoted
-        elif sline[0] in "\"'":
-            q = sline[0]
+        elif line[0] in "\"'":
+            q = line[0]
             mo = re.match(
                 rf"{q}(?P<key>([^{q}]|({q}{q}))*?){q}\s*:\s+(?P<value>.*)",
-                sline)
+                line)
             if mo is None:
                 raise error("invalid quoted key")
             key, value = mo.group("key", "value")
             key = key.replace(2 * q, q)
-            value = value.strip()
         # Key is normal
         else:
-            mo = re.match(r"(.*?):(\s+|$)(.*)", sline)
+            mo = re.match(r"(.*?):(\s+|$)(.*)", line)
             if mo is None:
-                if ":" in sline:
+                if ":" in line:
                     raise error("colon at the end of the key should be "
                                 "followed by a space or a new line")
                 else:
                     raise error("key followed by colon expected")
             key, _, value = mo.groups()
-            value = value.strip()
 
+        # `value` is lstripped, but may contain whitespace at the end
+        # This is needed for triple-quoted values
         # Leaves
-        if value:
-            # Value is block
-            if value[0] in "|":
+        if svalue := value.strip():
+            # Value is triple-quoted block
+            if value[:3] in ("'''", '"""'):
+                value, after = read_triple_quoted_block(value, linegen.line_no)
+                if after.strip():
+                    error("triple-quoted value must be followed by end of line")
+            # Value is block - for backward compatibility
+            elif value[0] in "|":
                 value = read_block(indent, value[1:])
             # value is quoted
-            elif _is_quoted_value(value):
-                value = value[1:-1]
+            elif _is_quoted_value(svalue):
+                value = svalue[1:-1]
             else:
                 value = {"true": True, "false": False, "null": None
-                         }.get(value, value)
+                         }.get(svalue, value)
             stack[-1][1][key] = MsgNode(value, comments or None)
         # Internal nodes
         else:
@@ -175,15 +204,15 @@ def readlines(lines):
 
 def dump(d, indent=""):
     def dumpb(s):
-        indent_spec = ' 4' if s[0] in ' \n\t' else ''
-        return f"|{indent_spec}\n" \
-               + "\n".join(f"{indent}    {v}" for v in s.splitlines())
+        q = "'''" if '"""' in s else '"""'
+        s.replace(q, ("\\" + q[0]) * 3)
+        return f"{q}{s}{q}"
 
     def dumpkey_msg(s):
         if "\n" in s:
-            return f"{dumpb(s)}\n{indent}"
+            return dumpb(s)
         if ": " in s or s[0] in " #\"'|" or s[-1] == " ":
-            q = '"' if s[0] == "'" else "'"
+            q = '"' if "'" in s else "'"
             return f"{q}{s.replace(q, 2 * q)}{q}"
         return s
 

--- a/trubar/tests/test_jaml.py
+++ b/trubar/tests/test_jaml.py
@@ -182,20 +182,20 @@ abc:
         self.assertEqual(tr[key].value, value)
         self.assertEqual(tr[key.replace("ghi", "ghi2")].value, value)
 
-    def test_read_triple_quoted_blocks(self):
+    def test_read_quoted_blocks(self):
         self.assertEqual(jaml.read('''a/b.py:
     def `f`:
-        """a
+        "a
 b
-c""": abc
-        abc: """
+c": abc
+        abc: "
      a
 ''' + " " * 5 + '''
    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-"""
+"
         foo: false
-        def: """a
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"""
+        def: "a
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 x/y.py: null
         '''),
          {"a/b.py":
@@ -212,28 +212,20 @@ x/y.py: null
     )
 
     def test_read_quotes_in_values(self):
-        text = """
-foo1: "bar
-foo2: bar"
-foo3: "bar"
-foo4: "ba"r"
-foo5: 'bar
-foo6: bar'
+        text = '''
+foo1: "bar"
+foo2: """bar"
+foo4: "ba""r"
+foo5: "bar"""
 foo7: 'bar' 
-foo8: 'ba'r' 
+foo8: 'ba''r' 
 foo9: 'ba"r'
-foo10: "bar'
-foo11: "bar'
-foo12: "ba"r" 
-foo13: 'ba'r'
-foo14: 'ba'r '
-"""
+foo12: "bar''" 
+'''
         msgs = jaml.read(text)
-        self.assertEqual([node.value for node in msgs.values()],
-                         ['"bar', 'bar"', 'bar', 'ba"r',
-                          "'bar", "bar'", "bar", "ba'r",
-                          'ba"r', "\"bar'", "\"bar'",
-                          'ba"r', "ba'r", "ba'r "])
+        self.assertEqual(
+            [node.value for node in msgs.values()],
+            ["bar", "\"bar", "ba\"r", "bar\"", "bar", "ba'r", 'ba"r', "bar''"])
 
     def test_read_quotes_in_keys(self):
         text = """
@@ -346,16 +338,14 @@ ghi: jkl
 
     def test_syntax_errors(self):
         self.assertRaisesRegex(
-            jaml.JamlError, "Line 1: invalid quoted key", jaml.read, "' ''x: y")
-        self.assertRaisesRegex(
             jaml.JamlError, "Line 1: file ends.*", jaml.read, "'''x: y")
         self.assertRaisesRegex(
-            jaml.JamlError, "Line 1: invalid quoted key", jaml.read, "'x: y")
+            jaml.JamlError, "Line 1: file ends.*", jaml.read, "'x: y")
         self.assertRaisesRegex(
-            jaml.JamlError, "Line 2: triple-quoted key must be followed .*",
+            jaml.JamlError, "Line 2: quoted key must be followed .*",
             jaml.read, '"""x\ny"""\na:b')
         self.assertRaisesRegex(
-            jaml.JamlError, "Line 2: triple-quoted value must be followed .*",
+            jaml.JamlError, "Line 2: quoted value must be followed .*",
             jaml.read, 'x: """\na""": b')
         self.assertRaisesRegex(
             jaml.JamlError, "Line 3: block key must be followed .*",
@@ -385,7 +375,7 @@ ghi: jkl
             tuv: bdf""",
         )
         self.assertRaisesRegex(
-            jaml.JamlError, "Line 4: invalid quoted key", jaml.read, """
+            jaml.JamlError, "Line 4: file ends", jaml.read, """
         abc:
             def:
                 "ghi: jkl
@@ -505,17 +495,17 @@ class `A`: false
                 }
         self.assertEqual(jaml.dump(tree), '''a/b.py:
     def `f`:
-        """a
+        'a
 b
-c""": abc
-        abc: """
+c': abc
+        abc: '
      a
 ''' + " " * 5 + '''
    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-"""
+'
         foo: false
-        def: """a
-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"""
+        def: 'a
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 x/y.py: null
 ''')
 

--- a/trubar/tests/test_messages.py
+++ b/trubar/tests/test_messages.py
@@ -71,12 +71,14 @@ class TestUtils(TestBase):
             self.assertRaises(SystemExit, load, "no such file")
             self.assertIn("not found", buf.getvalue())
 
-    def test_loader_verifies_sanity(self):
+    @patch("builtins.print")
+    def test_loader_verifies_sanity(self, a_print):
         fn = self.prepare_file("x.jaml", """
         class `A`:
             def `foo`: bar
         """)
         self.assertRaises(SystemExit, load, fn)
+        a_print.assert_called()
 
     def test_check_sanity(self):
         # unexpected namespace


### PR DESCRIPTION
This makes messages much easier to read and less ambiguous wrt white space at the beginning.

At the same time, parser and dumper are way simpler and thus safer.

No backward compatibility. Still, it took me five minutes to adapt the entire collection of messages for Orange.