### PR TITLE
Requires -s; check for matches, recommend different dir if there are none

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -328,7 +328,7 @@ int-import-graph=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception
 
 [isort]
 known-standard-library=pkg_resources

--- a/trubar/tests/shell_tests/collect/test.sh
+++ b/trubar/tests/shell_tests/collect/test.sh
@@ -58,3 +58,22 @@ then
     echo "Non-zero exit code expected"
     exit 1
 fi
+set -e
+
+set +e
+echo "... invalid source dir correction"
+cp some_messages.yaml tmp/some_messages.yaml
+print_run 'trubar collect -s .. tmp/some_messages.yaml' tmp/output.txt
+if [ $? -eq 0 ]
+then
+    echo "Non-zero exit code expected"
+    exit 1
+fi
+grep -q "instead" tmp/output.txt
+if [ $? -ne 0 ]
+then
+    echo "No error message"
+    exit 1
+fi
+set -e
+rm tmp/some_messages.yaml tmp/output.txt

--- a/trubar/tests/shell_tests/translate/test.sh
+++ b/trubar/tests/shell_tests/translate/test.sh
@@ -56,3 +56,20 @@ if [[ ! -z $(cat tmp/verb_output) ]] ; then
     exit 1
 fi
 rm tmp/verb_output
+
+echo "... invalid source dir correction"
+set +e
+print_run 'trubar translate -s .. -d tmp/si_foo translations.yaml' tmp/output.txt
+if [ $? -eq 0 ]
+then
+    echo "Non-zero exit code expected"
+    exit 1
+fi
+grep -q "instead" tmp/output.txt
+if [ $? -ne 0 ]
+then
+    echo "No recommendation is given"
+    exit 1
+fi
+set -e
+rm tmp/output.txt

--- a/trubar/tests/test_utils.py
+++ b/trubar/tests/test_utils.py
@@ -1,0 +1,182 @@
+import os
+from pathlib import PureWindowsPath
+
+import unittest
+
+from unittest.mock import patch, Mock
+
+from trubar.utils import walk_files, check_any_files
+from trubar.config import config
+import trubar.tests.test_module
+
+
+test_module_path = os.path.split(trubar.tests.test_module.__file__)[0]
+
+
+class UtilsTest(unittest.TestCase):
+    def test_walk_files(self):
+        tmp = test_module_path
+        old_pattern = config.exclude_pattern
+        try:
+            config.set_exclude_pattern("")
+            self.assertEqual(
+                set(walk_files(tmp, select=True)),
+                {('bar_module/__init__.py',
+                  f'{tmp}/bar_module/__init__.py'),
+                 ('bar_module/foo_module/__init__.py',
+                  f'{tmp}/bar_module/foo_module/__init__.py'),
+                 ('baz_module/__init__.py',
+                  f'{tmp}/baz_module/__init__.py'),
+                 ('__init__.py',
+                  f'{tmp}/__init__.py')}
+            )
+
+            old_path = os.getcwd()
+            try:
+                os.chdir(tmp)
+                self.assertEqual(
+                    set(walk_files(".", select=True)),
+                    {('bar_module/__init__.py',
+                      './bar_module/__init__.py'),
+                     ('bar_module/foo_module/__init__.py',
+                      './bar_module/foo_module/__init__.py'),
+                     ('baz_module/__init__.py',
+                      './baz_module/__init__.py'),
+                     ('__init__.py',
+                      './__init__.py')}
+                )
+                self.assertEqual(
+                    set(walk_files(".", "bar", select=True)),
+                    {('bar_module/__init__.py',
+                      './bar_module/__init__.py'),
+                     ('bar_module/foo_module/__init__.py',
+                      './bar_module/foo_module/__init__.py')}
+                )
+            finally:
+                os.chdir(old_path)
+
+            self.assertEqual(
+                set(walk_files(tmp, select=False)),
+                {('bar_module/__init__.py',
+                  f'{tmp}/bar_module/__init__.py'),
+                 ('bar_module/foo_module/__init__.py',
+                  f'{tmp}/bar_module/foo_module/__init__.py'),
+                 ('baz_module/__init__.py',
+                  f'{tmp}/baz_module/__init__.py'),
+                 ('__init__.py',
+                  f'{tmp}/__init__.py'),
+                 ('baz_module/not-python.js',
+                  f'{tmp}/baz_module/not-python.js')}
+            )
+
+            config.set_exclude_pattern("b?r_")
+            self.assertEqual(
+                set(walk_files(tmp, select=False)),
+                {('bar_module/__init__.py',
+                  f'{tmp}/bar_module/__init__.py'),
+                 ('bar_module/foo_module/__init__.py',
+                  f'{tmp}/bar_module/foo_module/__init__.py'),
+                 ('baz_module/__init__.py',
+                  f'{tmp}/baz_module/__init__.py'),
+                 ('__init__.py',
+                  f'{tmp}/__init__.py'),
+                 ('baz_module/not-python.js',
+                  f'{tmp}/baz_module/not-python.js')}
+            )
+            self.assertEqual(
+                set(walk_files(tmp, select=True)),
+                {('baz_module/__init__.py',
+                  f'{tmp}/baz_module/__init__.py'),
+                 ('__init__.py',
+                  f'{tmp}/__init__.py')}
+            )
+        finally:
+            config.set_exclude_pattern(old_pattern)
+
+    @patch("os.walk",
+           return_value=[(r"c:\foo\bar\ann\bert",
+                          None,
+                          ["cecil.py", "dan.txt", "emily.py"])]
+           )
+    @patch("os.path.join", new=lambda *c: "\\".join(c))
+    @patch("trubar.utils.PurePath", new=PureWindowsPath)
+    def test_walk_backslashes_on_windows(self, _):
+        self.assertEqual(
+            list(walk_files(r"c:\foo\bar", select=False)),
+            [("ann/bert/cecil.py", r"c:\foo\bar\ann\bert\cecil.py"),
+             ("ann/bert/dan.txt", r"c:\foo\bar\ann\bert\dan.txt"),
+             ("ann/bert/emily.py", r"c:\foo\bar\ann\bert\emily.py")]
+        )
+        self.assertEqual(
+            list(walk_files(r"c:\foo\bar", "l", select=False)),
+            [("ann/bert/cecil.py", r"c:\foo\bar\ann\bert\cecil.py"),
+             ("ann/bert/emily.py", r"c:\foo\bar\ann\bert\emily.py")])
+        # Don't match pattern in path
+        self.assertEqual(
+            list(walk_files(r"c:\foo\bar", "o", select=False)),
+            [])
+
+    @patch("sys.exit")
+    @patch("builtins.print")
+    def test_check_any_files(self, print_, exit_):
+        keys = "a/x.py a/y.py a/b/x.py a/b/z.py".split()
+        translations = dict.fromkeys(keys)
+        with patch("trubar.utils.walk_files",
+                   Mock(return_value=[(k, k) for k in keys])):
+            check_any_files(translations, "foo/bar")
+            exit_.assert_not_called()
+            print_.assert_not_called()
+
+        with patch("trubar.utils.walk_files",
+                   Mock(return_value=[("t/x/" + k, k) for k in keys])):
+            check_any_files(translations, "foo/bar")
+            exit_.assert_called()
+            print_.assert_called()
+            msg = print_.call_args[0][0]
+            self.assertIn("-s foo/bar/t/x", msg)
+            print_.reset_mock()
+            exit_.reset_mock()
+
+            home = os.path.expanduser("~/foo/bar")
+            check_any_files(translations, home)
+            exit_.assert_called()
+            msg = print_.call_args[0][0]
+            self.assertIn("-s ~/foo/bar/t/x", msg)
+            print_.reset_mock()
+            exit_.reset_mock()
+
+            with patch("sys.platform", "win32"):
+                check_any_files(translations, home)
+                exit_.assert_called()
+                print_.assert_called()
+                msg = print_.call_args[0][0]
+                print_.assert_called()
+                self.assertIn(f"-s {home}/t/x", msg)
+                print_.reset_mock()
+                exit_.reset_mock()
+
+        keys = "a/x.py a/y.py a/b/x.py a/b/z.py a/b/u.py".split()
+        with patch("trubar.utils.walk_files",
+                   Mock(return_value=[(k, k) for k in keys])):
+            check_any_files(dict.fromkeys(["x.py", "z.py", "u.py"]), "foo")
+            exit_.assert_called()
+            print_.assert_called()
+            msg = print_.call_args[0][0]
+            self.assertIn("-s foo/a/b", msg)
+            print_.reset_mock()
+            exit_.reset_mock()
+
+        keys = "a/x.py a/y.py a/b/x.py a/b/z.py".split()
+        with patch("trubar.utils.walk_files",
+                   Mock(return_value=[(k, k) for k in keys])):
+            check_any_files(dict.fromkeys(["x.py", "z.py", "u.py"]), "foo")
+            exit_.assert_called()
+            print_.assert_called()
+            msg = print_.call_args[0][0]
+            self.assertNotIn("-s foo/a/b", msg)
+            print_.reset_mock()
+            exit_.reset_mock()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trubar/utils.py
+++ b/trubar/utils.py
@@ -1,0 +1,53 @@
+import os
+import sys
+from pathlib import PurePath
+from typing import Iterator, Tuple
+
+from trubar.config import config
+from trubar.messages import MsgDict
+
+
+def walk_files(path: str, pattern: str = "", *, select: bool
+               ) -> Iterator[Tuple[str, str]]:
+    path = os.path.normpath(path)
+    for dirpath, _, files in sorted(os.walk(path)):
+        for name in sorted(files):
+            if select and not name.endswith(".py"):
+                continue
+            name = os.path.join(dirpath, name)
+            keyname = PurePath(name[len(path) + 1:]).as_posix()
+            if pattern in keyname and \
+                    not (select and config.exclude_re
+                         and config.exclude_re.search(keyname)):
+                yield keyname, name
+
+
+def check_any_files(translations: MsgDict, path: str):
+    source_keys = {n for n, _ in walk_files(path, "", select=True)}
+    trans_keys = set(translations)
+    if not trans_keys or source_keys & trans_keys:
+        return
+    suggestion = ""
+    best_matched = 2  # Require at least three matches to make a suggestion
+    tried = set()
+    for fname in source_keys:
+        start = ""
+        for part in fname.split("/")[:3]:
+            start += part + "/"
+            if start in tried:
+                continue
+            tried.add(start)
+            matched = len(source_keys & {start + k for k in translations})
+            if matched > best_matched:
+                best_matched = matched
+                suggestion = start
+    if suggestion:
+        suggestion = os.path.join(path, suggestion[:-1])
+        if sys.platform != "win32":
+            home = os.path.expanduser("~")
+            if suggestion.startswith(home):
+                suggestion = "~/" + suggestion[len(home) + 1:]
+        suggestion = f"; try -s {suggestion} instead"
+    print("Paths in translations do not match any existing files.\n"
+          f"One reason may be an incorrect source path{suggestion}.")
+    sys.exit(5)


### PR DESCRIPTION
Fixes #72.

Also: `-s` is now required argument for `collect` and `translate`.