### PR TITLE
Merge: Fix unused reporting and tests

### DIFF
--- a/trubar/__main__.py
+++ b/trubar/__main__.py
@@ -161,7 +161,7 @@ def main() -> None:
         additional = load(args.translations)
         existing = load(args.messages)
         unused = merge(additional, existing, pattern,
-                       print_unused=bool(args.unused))
+                       print_unused=not args.unused)
         if not args.dry_run:
             dump(existing, args.output or args.messages)
         if args.unused and unused:

--- a/trubar/tests/shell_tests/merge/test.sh
+++ b/trubar/tests/shell_tests/merge/test.sh
@@ -27,16 +27,23 @@ print_run 'trubar merge faulty_translations.yaml tmp/translations-copy.yaml -o t
 diff tmp/translations-copy.yaml translations.yaml
 diff tmp/updated_translations.yaml exp/updated_translations_faulty.yaml
 diff tmp/unused.yaml exp/unused.yaml
-diff tmp/errors.txt exp/errors.txt
+if [[ ! -z $(cat tmp/errors.txt) ]]
+then
+    echo "merge mustn't output unused items when writing them to a file"
+    cat tmp/errors.txt
+    exit 1
+fi
 rm tmp/updated_translations.yaml tmp/unused.yaml tmp/errors.txt
 
 echo "... dry-run, with errors"
 print_run 'trubar merge faulty_translations.yaml tmp/translations-copy.yaml -u tmp/unused.yaml -n' tmp/errors.txt
 diff tmp/translations-copy.yaml translations.yaml
 diff tmp/unused.yaml exp/unused.yaml
-if [[ ! -z $(cat errors.txt) ]]
+if [[ ! -z $(cat tmp/errors.txt) ]]
 then
     echo "merge mustn't output unused items when writing them to a file"
+    cat tmp/errors.txt
+    exit 1
 fi
 rm tmp/unused.yaml tmp/errors.txt
 


### PR DESCRIPTION
Errors were reported when also written to a file. They'd have to be reported when *not* written.

Tests had another, unrelated bug.