### PR TITLE
Load config from .trubarconfig and from source path

### DIFF
--- a/trubar/__main__.py
+++ b/trubar/__main__.py
@@ -19,6 +19,22 @@ def check_dir_exists(path):
         sys.exit(2)
 
 
+def load_config(args):
+    if args.conf:
+        config.update_from_file(args.conf)
+        return
+
+    paths = [""]
+    if hasattr(args, "source"):
+        paths.append(args.source)
+    for path in paths:
+        for name in (".trubarconfig.yaml", "trubar-config.yaml"):
+            fullname = os.path.join(path, name)
+            if os.path.exists(fullname):
+                config.update_from_file(fullname)
+                return
+
+
 def main() -> None:
     def add_parser(name, desc):
         subparser = subparsers.add_parser(name, help=desc, description=desc)
@@ -121,12 +137,7 @@ def main() -> None:
         help="file with messages")
 
     args = argparser.parse_args(sys.argv[1:])
-
-    if args.conf:
-        config.update_from_file(args.conf)
-    elif os.path.exists("trubar-config.yaml"):
-        config.update_from_file("trubar-config.yaml")
-
+    load_config(args)
     pattern = args.pattern
 
     if args.action == "collect":

--- a/trubar/tests/shell_tests/_config/.trubarconfig.yaml
+++ b/trubar/tests/shell_tests/_config/.trubarconfig.yaml
@@ -1,0 +1,1 @@
+auto-import: "from foo import something_fancy"

--- a/trubar/tests/test_main.py
+++ b/trubar/tests/test_main.py
@@ -2,7 +2,8 @@ import os
 import unittest
 from unittest.mock import patch
 
-from trubar.__main__ import check_dir_exists
+from trubar.config import config
+from trubar.__main__ import check_dir_exists, load_config
 
 import trubar.tests.test_module
 
@@ -22,6 +23,36 @@ class TestUtils(unittest.TestCase):
 
         self.assertRaises(SystemExit, check_dir_exists, "no_such_path")
         self.assertNotIn("not a directory", print_.call_args[0][0])
+
+    @patch.object(config, "update_from_file")
+    def test_load_config(self, update):
+        class Args:
+            source = os.path.join("x", "y", "z")
+            conf = ""
+
+        args = Args()
+
+        args.conf = "foo.yaml"
+        load_config(args)
+        update.assert_called_with("foo.yaml")
+        update.reset_mock()
+        args.conf = ""
+
+        with patch("os.path.exists",
+                   lambda x: os.path.split(x)[-1] in ("trubar-config.yaml",
+                                                      ".trubarconfig.yaml")):
+            load_config(args)
+        update.assert_called_with(".trubarconfig.yaml")
+
+        with patch("os.path.exists",
+                   lambda x: os.path.split(x)[-1] == "trubar-config.yaml"):
+            load_config(args)
+        update.assert_called_with("trubar-config.yaml")
+
+        confile = os.path.join(args.source, ".trubarconfig.yaml")
+        with patch("os.path.exists", lambda x: x == confile):
+            load_config(args)
+        update.assert_called_with(confile)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #73.

Default config file used to be trubar-config.yaml. It still is, but now it can also be .trubarconfig.yaml, and it has precedence.

Also, if there is no config file in the existing directory, it is loaded from source path (for `translate` and `collect`, which have `-s` option).