### PR TITLE
Collect: do not add files without messages to translation files

### DIFF
--- a/trubar/actions.py
+++ b/trubar/actions.py
@@ -231,7 +231,7 @@ def collect(source: str,
                 messages[name] = collected
             if name in existing:
                 removals = MsgNode(merge(
-                    existing.pop(name).value, messages[name].value,
+                    existing.pop(name).value, collected.value,
                     "", name, print_unused))
                 if removals.value:
                     removed[name] = removals


### PR DESCRIPTION
`collect` shouldn't include files without messages. Also because jaml cannot represent them, therefore creating an invalid file.