### PR TITLE
Collect: Always store unused translations

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -44,7 +44,7 @@ messages are removed.
 : Gives a pattern that the file path must include to be considered. The pattern is checked against the entire path; e.g. `-p rm/pi` would match the path `farm/pigs.py:`.
 
 `-r <removed-translations>`, `--removed <removed-translations>`
-: The name of the file for messages that were present in the messages file but no longer needed.
+: The name of the file for messages that were present in the messages file but no longer needed. If omitted, removed translations, if any, are saved to file `removed-from-<messages>`, where message is the name of the message file. If the file already exists `(<n>)` is appended to the name.
 
 `-n`, `--dry-run`: Run, but do not change the output file. The file with removed messages is still written.
 

--- a/trubar/__main__.py
+++ b/trubar/__main__.py
@@ -7,7 +7,7 @@ from trubar.actions import \
     ReportCritical
 from trubar.messages import load, dump
 from trubar.config import config
-from trubar.utils import check_any_files
+from trubar.utils import check_any_files, dump_removed
 
 
 def check_dir_exists(path):
@@ -153,11 +153,10 @@ def main() -> None:
         else:
             existing = {}
         messages, removed = collect(args.source, existing, pattern,
-                                    quiet=args.quiet, print_unused=not args.removed)
-        if args.removed and removed:
-            dump(removed, args.removed)
+                                    quiet=args.quiet)
         if not args.dry_run:
             dump(messages, args.messages)
+        dump_removed(removed, args.removed, args.messages)
 
     elif args.action == "translate":
         check_dir_exists(args.source)

--- a/trubar/actions.py
+++ b/trubar/actions.py
@@ -219,7 +219,7 @@ class StringTranslator(cst.CSTTransformer):
 def collect(source: str,
             existing: Optional[MsgDict] = None,
             pattern: str = "",
-            *, quiet=False, print_unused=True) -> Tuple[MsgDict, MsgDict]:
+            *, quiet=False) -> Tuple[MsgDict, MsgDict]:
     messages = {}
     removed = {}
     for name, fullname in walk_files(source, "", select=True):
@@ -232,7 +232,7 @@ def collect(source: str,
             if name in existing:
                 removals = MsgNode(merge(
                     existing.pop(name).value, collected.value,
-                    "", name, print_unused))
+                    "", name, print_unused=False))
                 if removals.value:
                     removed[name] = removals
         elif name in existing:
@@ -241,10 +241,6 @@ def collect(source: str,
     existing = {name: trans for name, trans in existing.items()
                 if _any_translations(trans.value)}
     removed.update(existing)
-    if print_unused and existing:
-        print("The following file(s) no longer exist:")
-        print("\n".join(f"- {name}" for name in existing))
-
     return messages, removed
 
 

--- a/trubar/tests/shell_tests/collect/test.sh
+++ b/trubar/tests/shell_tests/collect/test.sh
@@ -26,6 +26,13 @@ diff tmp/some_messages.yaml exp/merged_messages.yaml
 diff tmp/removed.yaml exp/removed.yaml
 rm tmp/some_messages.yaml tmp/removed.yaml
 
+echo "... merge with existing file, default removed file"
+cp some_messages.yaml tmp/some_messages.yaml
+print_run 'trubar collect -s ../test_project tmp/some_messages.yaml -q'
+diff tmp/some_messages.yaml exp/merged_messages.yaml
+diff tmp/removed-from-some_messages.yaml exp/removed.yaml
+rm tmp/some_messages.yaml tmp/removed-from-some_messages.yaml
+
 echo "... merge with existing file, with pattern"
 cp some_messages.yaml tmp/some_messages.yaml
 print_run 'trubar collect -s ../test_project -r tmp/removed.yaml -p submodule tmp/some_messages.yaml -q'
@@ -40,17 +47,12 @@ diff tmp/some_messages.yaml some_messages.yaml
 diff tmp/removed.yaml exp/removed.yaml
 rm tmp/some_messages.yaml tmp/removed.yaml
 
-echo "... merge with existing file, dry run, no removed"
+echo "... merge with existing file, dry run, default removed file"
 cp some_messages.yaml tmp/some_messages.yaml
 print_run 'trubar collect -s ../test_project tmp/some_messages.yaml -n -q' tmp/removed_output
 diff tmp/some_messages.yaml some_messages.yaml
-diff tmp/removed_output exp/removed_output
-if [ -d tmp/some_messages.yaml ]
-then
-  echo "Not dry."
-  exit 1
-fi
-rm tmp/some_messages.yaml
+diff tmp/removed-from-some_messages.yaml exp/removed.yaml
+rm tmp/some_messages.yaml tmp/removed-from-some_messages.yaml
 
 echo "... invalid source dir"
 set +e

--- a/trubar/tests/test_actions.py
+++ b/trubar/tests/test_actions.py
@@ -260,8 +260,7 @@ class ActionsTest(unittest.TestCase):
                            "foo": None, "bar": "baz"},
                 "b/e.py": {"qux": None},
                 "b/f.py": {"qui": "quo"}})
-            mess, remo = collect("", deepcopy(existing), "",
-                                 quiet=True, print_unused=False)
+            mess, remo = collect("", deepcopy(existing), "", quiet=True)
             self.assertEqual(
                 mess,
                 dict_to_msg_nodes({
@@ -279,10 +278,6 @@ class ActionsTest(unittest.TestCase):
             )
             print_.assert_not_called()
 
-            collect("", deepcopy(existing), "", quiet=True)
-            print_.assert_called()
-            print_.reset_mock()
-
             existing = dict_to_msg_nodes({
                 "b/d.py": {"def `d`": {"dd": "dtrans", "ddd": None},
                            "foo": None, "bar": "baz"},
@@ -293,8 +288,7 @@ class ActionsTest(unittest.TestCase):
             })
             file_list += [("b/e.py", "x/b/e.py"),
                           ("b/f.py", "x/b/f.py")]
-            mess, remo = collect("", deepcopy(existing), "d",
-                                 quiet=True, print_unused=False)
+            mess, remo = collect("", deepcopy(existing), "d", quiet=True)
             self.assertEqual(
                 mess,
                 dict_to_msg_nodes({
@@ -311,10 +305,6 @@ class ActionsTest(unittest.TestCase):
                 })
             )
             print_.assert_not_called()
-
-            collect("", deepcopy(existing), "d", quiet=True)
-            print_.assert_called()
-            print_.reset_mock()
 
     @patch("builtins.print")
     def test_collect_empty_file(self, _):


### PR DESCRIPTION
Fixes #88.

Collect now
- always writes a files with removed messages,
- no longer prints out warnings about removed messages.