### PR TITLE
Collect: add option --newer

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -43,6 +43,9 @@ messages are removed.
 `-p <pattern>`, `--pattern <pattern>`
 : Gives a pattern that the file path must include to be considered. The pattern is checked against the entire path; e.g. `-p rm/pi` would match the path `farm/pigs.py:`.
 
+`-u`, `--newer`
+: Only consider source files that are newer than the message file (if it exists).
+
 `-r <removed-translations>`, `--removed <removed-translations>`
 : The name of the file for messages that were present in the messages file but no longer needed. If omitted, removed translations, if any, are saved to file `removed-from-<messages>`, where message is the name of the message file. If the file already exists `(<n>)` is appended to the name.
 

--- a/pylintrc
+++ b/pylintrc
@@ -55,7 +55,9 @@ confidence=
 disable=
     missing-docstring,              # I guess not
     no-else-return, no-else-raise,  # else's may actually improve readability
-    too-many-branches               # distracting rather than helpful
+    too-many-branches,              # distracting rather than helpful
+    duplicate-code,                 # I trust myself on this one
+    cyclic-import                   # weird false positive, can only disable globally
 
 
 [REPORTS]

--- a/trubar/__main__.py
+++ b/trubar/__main__.py
@@ -56,6 +56,9 @@ def main() -> None:
         "-s", "--source", metavar="source-dir",
         required=True, help="source path")
     parser.add_argument(
+        "-u", "--newer", action="store_true",
+        help="check only source files that are newer than the message file")
+    parser.add_argument(
         "messages", metavar="messages",
         help="existing or new file with messages")
     parser.add_argument(
@@ -146,14 +149,17 @@ def main() -> None:
     pattern = args.pattern
 
     if args.action == "collect":
+        min_time = None
         check_dir_exists(args.source)
         if os.path.exists(args.messages):
             existing = load(args.messages)
             check_any_files(existing, args.source)
+            if args.newer:
+                min_time = os.stat(args.messages).st_mtime
         else:
             existing = {}
         messages, removed = collect(args.source, existing, pattern,
-                                    quiet=args.quiet)
+                                    quiet=args.quiet, min_time=min_time)
         if not args.dry_run:
             dump(messages, args.messages)
         dump_removed(removed, args.removed, args.messages)

--- a/trubar/actions.py
+++ b/trubar/actions.py
@@ -219,11 +219,14 @@ class StringTranslator(cst.CSTTransformer):
 def collect(source: str,
             existing: Optional[MsgDict] = None,
             pattern: str = "",
-            *, quiet=False) -> Tuple[MsgDict, MsgDict]:
+            *, quiet=False, min_time=None) -> Tuple[MsgDict, MsgDict]:
     messages = {}
     removed = {}
+    # No pattern when calling walk_files: we must get all files so that
+    # existing messages in skipped files are kept. We check the pattern here.
     for name, fullname in walk_files(source, "", select=True):
-        if pattern in name:
+        if pattern in name and (
+                min_time is None or os.stat(fullname).st_mtime >= min_time):
             if not quiet:
                 print(f"Parsing {name}")
             collected = StringCollector.parse_file(fullname)

--- a/trubar/tests/shell_tests/collect/exp/merged_messages_newer.yaml
+++ b/trubar/tests/shell_tests/collect/exp/merged_messages_newer.yaml
@@ -1,0 +1,19 @@
+__init__.py:
+    class `A`:
+        def `f`:
+            default: null
+            some/directory: null
+            File {x}: null
+            Not file {x + ".bak"}: null
+            Extra message: Posebno sporočilo
+            Untranslated messages: null
+            '{"nonsense"}': null
+    __main__: null
+    Please don't run this.: null
+    Import it, if you must.: null
+submodule/apples.py:
+    Oranges: Pomaranče
+trash/nothing.py:
+    def `f`:
+        To see here: Videti tukaj?
+        ', really.': null

--- a/trubar/tests/shell_tests/collect/exp/removed_newer.yaml
+++ b/trubar/tests/shell_tests/collect/exp/removed_newer.yaml
@@ -1,0 +1,2 @@
+submodule/apples.py:
+    Lemons: Limone

--- a/trubar/tests/shell_tests/collect/test.sh
+++ b/trubar/tests/shell_tests/collect/test.sh
@@ -26,6 +26,17 @@ diff tmp/some_messages.yaml exp/merged_messages.yaml
 diff tmp/removed.yaml exp/removed.yaml
 rm tmp/some_messages.yaml tmp/removed.yaml
 
+echo "... merge with existing file, with --newer"
+cp some_messages.yaml tmp/some_messages.yaml
+touch -t 11111230.00 ../test_project/__init__.py
+touch -t 11111239.00 tmp/some_messages.yaml
+touch -t 11111239.00 ../test_project/submodule/apples.py
+touch -t 11111245.00 ../test_project/trash/nothing.py
+print_run 'trubar collect -s ../test_project -r tmp/removed.yaml --newer tmp/some_messages.yaml -q'
+diff tmp/some_messages.yaml exp/merged_messages_newer.yaml
+diff tmp/removed.yaml exp/removed_newer.yaml
+rm tmp/some_messages.yaml tmp/removed.yaml
+
 echo "... merge with existing file, default removed file"
 cp some_messages.yaml tmp/some_messages.yaml
 print_run 'trubar collect -s ../test_project tmp/some_messages.yaml -q'

--- a/trubar/tests/test_messages.py
+++ b/trubar/tests/test_messages.py
@@ -169,7 +169,7 @@ module2/def `g`: Unexpectedly not a namespace
 
     @patch("builtins.open")
     @patch("yaml.dump")
-    @patch("trubar.jaml.dump")
+    @patch("trubar.jaml.dump")  # pylint wtf?, pylint: disable=cyclic-import
     def test_dump(self, jaml_dump, yaml_dump, _):
         msgdict = {"x": MsgNode("foo", ["bar", "baz"])}
         dump(msgdict, "x.jaml")


### PR DESCRIPTION
`collect` for a large project may be slow although there are usually only a few files are modified and need to be checked.

With the new option `--newer` (`-u`), trubar compares timestamps before collecting messages from the file.