### PR TITLE
Minor fixes in jaml and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,13 @@ on:
     branches: [ "master" ]
 
 jobs:
-  build:
+  test-translations:
 
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
         python setup.py install
     - name: Run tests
       run: |

--- a/trubar/jaml.py
+++ b/trubar/jaml.py
@@ -46,6 +46,7 @@ def readlines(lines):
     comments = []
     comment_start = None
     linegen = enumerate(lines, start=1)
+    lineno, line = 0, ""  # for error reporting for empty files
     for lineno, line in linegen:
         # Skip empty lines
         if not line.strip():
@@ -123,7 +124,8 @@ def readlines(lines):
 
 def dump(d, indent=""):
     def quotescape(s, allow_colon):
-        if "\n" in s \
+        if not s \
+                or "\n" in s \
                 or ": " in s and not allow_colon \
                 or s[0] in " #\"'|" \
                 or s[-1] in " \t\n":

--- a/trubar/tests/test_jaml.py
+++ b/trubar/tests/test_jaml.py
@@ -63,6 +63,9 @@ class `B`:
              })
             })
 
+    def test_read_empty_file(self):
+        self.assertRaisesRegex(jaml.JamlError, "unexpected end", jaml.read, "")
+
     def test_read_quoted_blocks(self):
         self.assertEqual(jaml.read('''a/b.py:
     def `f`:
@@ -272,6 +275,7 @@ class JamlDumperTest(unittest.TestCase):
                                                   "baz": MsgNode(None, ["# eh"])}),
                                "yada": MsgNode(comments=["# bada", "# boom"],
                                                value=True),
+                               "": MsgNode(""),
                                }),
                 "class `A`":
                     MsgNode(value=False)}
@@ -290,6 +294,7 @@ a/b.py:
     # bada
     # boom
     yada: true
+    '': ""
 class `A`: false
 """[1:])
 

--- a/trubar/tests/test_messages.py
+++ b/trubar/tests/test_messages.py
@@ -169,7 +169,7 @@ module2/def `g`: Unexpectedly not a namespace
 
     @patch("builtins.open")
     @patch("yaml.dump")
-    @patch("trubar.jaml.dump")  # pylint wtf?, pylint: disable=cyclic-import
+    @patch("trubar.jaml.dump")
     def test_dump(self, jaml_dump, yaml_dump, _):
         msgdict = {"x": MsgNode("foo", ["bar", "baz"])}
         dump(msgdict, "x.jaml")


### PR DESCRIPTION
- Add tests on Python 3.11 and 3.12
- Fix a crash when reading jaml empty files and writing empty strings to jaml
- Remove a pylint disable that is now redundant