### PR TITLE
Set default locale to utf-8

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,5 +27,5 @@ The available options are
 `exclude-pattern` (default: `"tests/test_"`)
 : A regular expression for filtering out the files that should not be translated. The primary use for this is to exclude unit tests.
 
-`encoding` (default: system locale)
+`encoding` (default: `"utf-8"`)
 : Characted encoding for .jaml files, such as `"utf-8"` or `"cp-1252"`.

--- a/trubar/config.py
+++ b/trubar/config.py
@@ -26,9 +26,7 @@ class Configuration:
 
     exclude_pattern: str = "tests/test_"
 
-    encoding: str = \
-        "locale" if sys.version_info >= (3, 10) \
-        else locale.getpreferredencoding(False)
+    encoding: str = "utf-8"
 
     languages = None
 


### PR DESCRIPTION
So that the conf file can be reliably read on computers with different locales