### PR TITLE
Fixes for multilingual mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.3.1  - 0.3.4
+
+#### Bug fixes
+
+- Put auto imports after the docstring to avoid breaking doctests.
+- In multilingual mode, ensure that all variables from the original f-strings appear in the closure.
+- Fixed glitches in writing of translation files.
+- Set the default encoding to utf-8 rather than locale.
+
+## 0.3 - 2024-06-13
+
+- Support for switching between different languages (provisional, may change)
+- Drop support for Python 3.8.
+
 ## 0.2.5 - 2024-01-17
 
 #### Bug fixes

--- a/pylintrc
+++ b/pylintrc
@@ -57,7 +57,8 @@ disable=
     no-else-return, no-else-raise,  # else's may actually improve readability
     too-many-branches,              # distracting rather than helpful
     duplicate-code,                 # I trust myself on this one
-    cyclic-import                   # weird false positive, can only disable globally
+    cyclic-import,                  # weird false positive, can only disable globally
+    too-many-positional-arguments   # a new, not entirely useful check
 
 
 [REPORTS]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 
 name = trubar
-version = 0.3.3
+version = 0.3.4
 author = Janez Demsar
 author_email = janez.demsar@fri.uni-lj.si
 description = Utility for translation of Python sources

--- a/trubar/actions.py
+++ b/trubar/actions.py
@@ -454,20 +454,17 @@ class StringTranslatorMultilingual(StringTranslatorBase):
         prefix = "f" + node.prefix if need_f else node.prefix
 
         idx = len(self.message_tables[0])
-        str_no_prefix = \
-            f"{node.prefix.replace('f', '')}{node.quote}{original}{node.quote}"
-
         if "f" in prefix:
             quote = self._get_quote(node, orig_str, messages, prefix, need_f)
             for message, table in zip(messages, self.message_tables):
                 table.append(f"{prefix}{quote}{message}{quote}")
-            trans = f'_tr.e(_tr.c({idx}, {str_no_prefix}))'
+            trans = f'_tr.e(_tr.c({idx}, {orig_str}))'
         else:
             for message, table in zip(messages, self.message_tables):
                 table.append(message
                              .encode('latin-1', 'backslashreplace')
                              .decode('unicode-escape'))
-            trans = f"_tr.m[{idx}, {str_no_prefix}]"
+            trans = f"_tr.m[{idx}, {orig_str}]"
         return cst.parse_expression(trans)
 
 

--- a/trubar/config.py
+++ b/trubar/config.py
@@ -14,6 +14,7 @@ class LanguageDef:
     international_name: str
     is_original: bool
 
+
 @dataclasses.dataclass
 class Configuration:
     base_dir: Optional[str] = None

--- a/trubar/config.py
+++ b/trubar/config.py
@@ -1,7 +1,6 @@
 import sys
 import os
 import re
-import locale
 import dataclasses
 from typing import Optional
 

--- a/trubar/tests/shell_tests/translate/exp/multilingual/__init__.py
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/__init__.py
@@ -16,9 +16,9 @@ class A:
 
         t = os.listdir(_tr.e(_tr.c(3, "some/directory")))
         for x in t:
-            print(_tr.e(_tr.c(4, "File {x}")))
-            print(_tr.e(_tr.c(5, 'Not file {x + ".bak"}')))
-            if x.endswith(_tr.e(_tr.c(6, """{"nonsense"}"""))):
+            print(_tr.e(_tr.c(4, f"File {x}")))
+            print(_tr.e(_tr.c(5, f'Not file {x + ".bak"}')))
+            if x.endswith(_tr.e(_tr.c(6, f"""{"nonsense"}"""))):
                 return x
 
 if __name__ == "__main__":

--- a/trubar/tests/shell_tests/translate/exp/multilingual/__init__.py
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/__init__.py
@@ -1,8 +1,8 @@
+"""Doc string"""
 from something import anythin
 from anything import something
 _tr = Translator("Orange", "biolab.si", "Orange")
 del Translator
-"""Doc string"""
 
 import os
 

--- a/trubar/tests/test_actions.py
+++ b/trubar/tests/test_actions.py
@@ -94,7 +94,7 @@ def f(x):
 
     def test_formatted_string(self):
         msgs = self.collect("""
-        
+
 def f(x):
     a = f"a string {x}"
     b = f'another string {2 + 2}'
@@ -120,10 +120,10 @@ class A:
             d = "foo"
             e = "bar"
         a = "baz"
-        
+
         class B:
            f = "baz"
-           
+
 class C:
     g = "crux" 
 """)
@@ -137,17 +137,17 @@ class C:
     def test_module_and_walk_and_collect(self):
         msgs, _ = collect(test_module_path, {}, "", quiet=True)
         self.assertEqual(
-             dict_from_msg_nodes(msgs),
+            dict_from_msg_nodes(msgs),
             {
-             'bar_module/foo_module/__init__.py': {
-                 "I've seen things you people wouldn't believe...": None},
-             'bar_module/__init__.py': {
-                 'Attack ships on fire off the shoulder of Orion...': None},
-             'baz_module/__init__.py': {'def `f`': {
-                 'I watched C-beams glitter in the dark near the Tannhäuser Gate.': None}},
-             '__init__.py': {'class `Future`': {
-                'All those moments will be lost in time, like tears in rain...': None,
-                'Time to die.': None}},
+                'bar_module/foo_module/__init__.py': {
+                    "I've seen things you people wouldn't believe...": None},
+                'bar_module/__init__.py': {
+                    'Attack ships on fire off the shoulder of Orion...': None},
+                'baz_module/__init__.py': {'def `f`': {
+                    'I watched C-beams glitter in the dark near the Tannhäuser Gate.': None}},
+                '__init__.py': {'class `Future`': {
+                    'All those moments will be lost in time, like tears in rain...': None,
+                    'Time to die.': None}},
             }
         )
 
@@ -166,7 +166,7 @@ def g(x):
         self.assertEqual(
             msgs,
             {'def `f`': {'not a docstring': None},
-                  'def `g`': {'bar': None}})
+             'def `g`': {'bar': None}})
 
     def test_no_strings_within_interpolation(self):
         msgs = self.collect("""a = f'x = {len("foo")} {"bar"}'""")
@@ -348,11 +348,13 @@ class C:
         trans_foo = {'class `A`': {'def `b`': {'def `c`': {'foo': 'sea food',
                                                            'bar': None},
                                                'baz': True,
-                                               'class `B`': {'baz{42}': False}}},
+                                               'class `B`': {
+                                                   'baz{42}': False}}},
                      'class `C`': {'crux': ""}}
 
         trans_fee = {'class `A`': {'def `b`': {'def `c`': {'bar': "no-bar"},
-                                               'class `B`': {'baz{42}': "bar(1)"}}}}
+                                               'class `B`': {
+                                                   'baz{42}': "bar(1)"}}}}
 
         trans_source, message_tables = self._translate(
             module, [trans_foo, trans_fee], True)
@@ -478,7 +480,8 @@ class C:
             node.quote = "'"
             self.assertRaises(
                 TranslationError,
-                m, node, "'a str'''ing'", ["a str'''ing", "one", "tw\"\"\"o{x}"],
+                m, node, "'a str'''ing'",
+                ["a str'''ing", "one", "tw\"\"\"o{x}"],
                 "", ["English"])
 
     def test_auto_prefix(self):
@@ -747,15 +750,15 @@ class ActionsTest(unittest.TestCase):
              "d": False,
              "e": True,
              "class `f`": {"g": "h",
-                 "i": False,
-                 "def `j`": {"a": None},
-                 "k": True},
+                           "i": False,
+                           "def `j`": {"a": None},
+                           "k": True},
              "def `k`": {"p": None},
              "m": None,
              "class `p`": {"q": "r"},
              "s": None,
              "def `t`": {"u": "v"}
-            }
+             }
         )
         removed = dict_from_msg_nodes(removed)
         self.assertEqual(set(removed), {"class `f`", "def `m`"})
@@ -777,16 +780,16 @@ def `m` not in target structure
             "c": False,
             "d": True,
             "e": None,
-            "f": { "g": "h", "i": False},
-            "j": { "k": False, "l": {"m": False, "n": False}}
+            "f": {"g": "h", "i": False},
+            "j": {"k": False, "l": {"m": False, "n": False}}
         }
         self.assertEqual(
             yamlized(template)(messages),
-           {"a": None,
-            "d": None,
-            "e": None,
-            "f": { "g": None}
-        }
+            {"a": None,
+             "d": None,
+             "e": None,
+             "f": {"g": None}
+             }
         )
         self.assertEqual(yamlized(template)(messages, "f"), {"f": {"g": None}})
         self.assertEqual(yamlized(template)(messages, "g"), {})

--- a/trubar/tests/test_actions.py
+++ b/trubar/tests/test_actions.py
@@ -287,11 +287,12 @@ print("samo {oklepaji}!")
                 "test here\nimport plural\nimport dual\n")
         )
 
+    def test_inport_after_docstring(self):
         module = CountImportsFromFutureTest.module_without_futures
         imports = "import plural\nimport dual"
         auto_import = cst.parse_module(imports).body
         tree = cst.parse_module(module)
-        translator = StringTranslator({}, tree, auto_import, 0)
+        translator = StringTranslator({}, tree, auto_import, 0, True)
         translated = tree.visit(translator)
         trans_source = tree.code_for_node(translated)
         self.assertEqual(

--- a/trubar/tests/test_actions.py
+++ b/trubar/tests/test_actions.py
@@ -366,7 +366,7 @@ class A:
         a = "baz"
 
         class B:
-           f = _tr.e(_tr.c(5, "baz{42}"))
+           f = _tr.e(_tr.c(5, f"baz{42}"))
 
 
 class C:
@@ -491,13 +491,13 @@ class C:
         # Original is an f-string, and so is one of translations, other is missing
         translation, tables = self._translate(
             "print(f'fo{o}')", [{"fo{o}": "do{n}t"}, {}])
-        self.assertEqual(translation, "print(_tr.e(_tr.c(0, 'fo{o}')))")
+        self.assertEqual(translation, "print(_tr.e(_tr.c(0, f'fo{o}')))")
         self.assertEqual(tables, [["f'fo{o}'"], ["f'do{n}t'"], ["f'fo{o}'"]])
 
         # Original is an f-string, translations are not
         translation, tables = self._translate(
             "print(f'fo{o}')", [{"fo{o}": "dont"}, {}])
-        self.assertEqual(translation, "print(_tr.e(_tr.c(0, 'fo{o}')))")
+        self.assertEqual(translation, "print(_tr.e(_tr.c(0, f'fo{o}')))")
         self.assertEqual(tables, [["f'fo{o}'"], ["f'dont'"], ["f'fo{o}'"]])
 
         # Original is not an f-string, one of translations is
@@ -516,15 +516,15 @@ class C:
         # Original has an f-string, and translations have different quotes
         translation, tables = self._translate(
             "print(f'foo')", [{"foo": "don't"}, {"foo": 'x"y'}])
-        self.assertEqual(translation, "print(_tr.e(_tr.c(0, 'foo')))")
+        self.assertEqual(translation, "print(_tr.e(_tr.c(0, f'foo')))")
         self.assertEqual(
             tables,
             [["f'''foo'''"], ["f'''don't'''"], ["f'''x\"y'''"]])
 
         # One language has an f-string, and translations have different quotes
         self._translate(
-          "print('foo')", [{"foo": "d{o}n't"}, {"foo": 'x"y'}])
-        self.assertEqual(translation, "print(_tr.e(_tr.c(0, 'foo')))")
+            "print('foo')", [{"foo": "d{o}n't"}, {"foo": 'x"y'}])
+        self.assertEqual(translation, "print(_tr.e(_tr.c(0, f'foo')))")
         self.assertEqual(
             tables,
             [["f'''foo'''"], ["f'''don't'''"], ["f'''x\"y'''"]])
@@ -538,7 +538,7 @@ class C:
             # Original has an f-string, but quotes are OK
             translation, tables = self._translate(
                 'print(f"foo")', [{"foo": "don't"}, {"foo": "x'y"}])
-            self.assertEqual(translation, 'print(_tr.e(_tr.c(0, "foo")))')
+            self.assertEqual(translation, 'print(_tr.e(_tr.c(0, f"foo")))')
             self.assertEqual(tables, [['f"foo"'], ['f"don\'t"'], ['f"x\'y"']])
 
     def test_syntax_error(self):


### PR DESCRIPTION
### Fix failing docstring tests in compiled code

Trubar puts auto imports before the docstring. This string is then no longer recognized as a docstring and will not be executed by docstring tests.

This PR checks for existence of a docstring and puts auto import after it (unless there are imports from future, which always come after the doc string).

### Fix variables missing from closures

In

```python
def f():
    x = 5
    def g():
        return f'foo {x}'
    return g()
```

The return statement is replaced with (essentially)

```python
    return eval(compile(m[0, 'foo {x}'], "<string>", "eval"))
```

where `m[0]` is `"f'foo {x}'"`. This fails because `x` does not appear in `eval`'s locals.

This PR fixes it by giving the original f-string as the second index:

```python
    return eval(compile(m[0, f'foo {x}'], "<string>", "eval"))
```
