### PR TITLE
Multilingual: let Python choose quote types; don't use f-strings for translations where not necessary

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,8 @@ The available options are
 `smart-quotes` (default: true)
 : If set to `false`, strings in translated sources will have the same quotes as in the original source. Otherwise, if translation of a single-quoted includes a single quote, Trubar will output a double-quoted string and vice-versa. If translated message contains both types of quotes, they must be escaped with backslash.
 
+    This setting has not effect in multilingual setup.
+
 `auto-prefix` (default: true)
 : If set, Trubar will turn strings into f-strings if translation contains braces and adding an f- prefix makes it a syntactically valid string, *unless* the original string already included braces, in which case this may had been a pattern for `str.format`.
 

--- a/trubar/tests/shell_tests/translate/exp/multilingual/i18n/English.json
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/i18n/English.json
@@ -1,1 +1,1 @@
-["English", "English", "\"default\"", "\"some/directory\"", "f\"File {x}\"", "f'Not file {x + \".bak\"}'", "f\"\"\"{\"nonsense\"}\"\"\"", "'Import it, if you must.'", "Oranges"]
+["English", "English", "'default'", "'some/directory'", "f'File {x}'", "f'Not file {x + \".bak\"}'", "f'{\"nonsense\"}'", "'Import it, if you must.'", "Oranges"]

--- a/trubar/tests/shell_tests/translate/exp/multilingual/i18n/English.json
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/i18n/English.json
@@ -1,1 +1,1 @@
-["English", "English", "f\"default\"", "f\"some/directory\"", "f\"File {x}\"", "f'Not file {x + \".bak\"}'", "f\"\"\"{\"nonsense\"}\"\"\"", "f'''Import it, if you must.'''", "Oranges"]
+["English", "English", "\"default\"", "\"some/directory\"", "f\"File {x}\"", "f'Not file {x + \".bak\"}'", "f\"\"\"{\"nonsense\"}\"\"\"", "'Import it, if you must.'", "Oranges"]

--- a/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Foolanguage.json
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Foolanguage.json
@@ -1,1 +1,1 @@
-["Foo", "Foolanguage", "\"befault\"", "f\"an {f} foo string\"", "f\"File {x}\"", "f'Ne datoteka {x + \".bak\"}'", "f\"\"\"{\"sense\"}\"\"\"", "f'''{x} +'\" {y}'''", "Flemons"]
+["Foo", "Foolanguage", "'befault'", "f'an {f} foo string'", "f'File {x}'", "f'Ne datoteka {x + \".bak\"}'", "f'{\"sense\"}'", "f'{x} +\\'\" {y}'", "Flemons"]

--- a/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Foolanguage.json
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Foolanguage.json
@@ -1,1 +1,1 @@
-["Foo", "Foolanguage", "f\"befault\"", "f\"an {f} foo string\"", "f\"File {x}\"", "f'Ne datoteka {x + \".bak\"}'", "f\"\"\"{\"sense\"}\"\"\"", "f'''{x} +'\" {y}'''", "Flemons"]
+["Foo", "Foolanguage", "\"befault\"", "f\"an {f} foo string\"", "f\"File {x}\"", "f'Ne datoteka {x + \".bak\"}'", "f\"\"\"{\"sense\"}\"\"\"", "f'''{x} +'\" {y}'''", "Flemons"]

--- a/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Slovenian.json
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Slovenian.json
@@ -1,1 +1,1 @@
-["Sloven\u0161\u010dina", "Slovenian", "f\"\"\"An {f} st'r\"i'''ng\"\"\"", "\"some/directory\"", "f\"Datoteka {x}\"", "f'Ne datoteka {x + \".bak\"}'", "f\"\"\"{\"nesmisel\"}\"\"\"", "'Import it, if you must.'", "Pomaran\u010de"]
+["Sloven\u0161\u010dina", "Slovenian", "f'An {f} st\\'r\"i\\'\\'\\'ng'", "'some/directory'", "f'Datoteka {x}'", "f'Ne datoteka {x + \".bak\"}'", "f'{\"nesmisel\"}'", "'Import it, if you must.'", "Pomaran\u010de"]

--- a/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Slovenian.json
+++ b/trubar/tests/shell_tests/translate/exp/multilingual/i18n/Slovenian.json
@@ -1,1 +1,1 @@
-["Sloven\u0161\u010dina", "Slovenian", "f\"An {f} string\"", "f\"some/directory\"", "f\"Datoteka {x}\"", "f'Ne datoteka {x + \".bak\"}'", "f\"\"\"{\"nesmisel\"}\"\"\"", "f'''Import it, if you must.'''", "Pomaran\u010de"]
+["Sloven\u0161\u010dina", "Slovenian", "f\"\"\"An {f} st'r\"i'''ng\"\"\"", "\"some/directory\"", "f\"Datoteka {x}\"", "f'Ne datoteka {x + \".bak\"}'", "f\"\"\"{\"nesmisel\"}\"\"\"", "'Import it, if you must.'", "Pomaran\u010de"]

--- a/trubar/tests/shell_tests/translate/multilingual/si/translations.jaml
+++ b/trubar/tests/shell_tests/translate/multilingual/si/translations.jaml
@@ -2,7 +2,7 @@ __init__.py:
     class `A`:
         A class attribute: false
         def `f`:
-            default: An {f} string
+            default: An {f} st'r"i'''ng
             some/directory: true
             File {x}: Datoteka {x}
             Not file {x + ".bak"}: Ne datoteka {x + ".bak"}


### PR DESCRIPTION
Fixes #98.

- Do not enforce quote types because they don't matter. Let Python choose them: just call `repr` to "uneval" a string
- Don't use f-strings for translations where not necessary.
- Do not unescape raw string where originals are not raw.